### PR TITLE
Adding support for multiple file extensions in sniff

### DIFF
--- a/src/helpers/sniff.js
+++ b/src/helpers/sniff.js
@@ -1,9 +1,12 @@
-var sniff = function(files, filetype, word, action) {
+var sniff = function(files, filetypes, word, action) {
     var filename, extension, changes;
+    if (typeof filetypes === 'string') {
+        filetypes = [filetypes];
+    }
     for (var i = 0; i < files.length; i++) {
         filename = files[i].name;
-        extension = filename.substr(filename.lastIndexOf('.'));
-        if (extension === '.' + filetype) {
+        extension = filename.substr(filename.lastIndexOf('.') + 1);
+        if (filetypes.indexOf(extension) !== -1) {
             changes = files[i].changes;
             for (var j = 0; j < changes.length; j++) {
                 if (isAddition(changes[j])) {
@@ -21,4 +24,3 @@ function isAddition(line) {
 }
 
 robocop.helpers.sniff = sniff;
-


### PR DESCRIPTION
If same action needs to be applied on multiple file types.
